### PR TITLE
feat: implement tile-based map service

### DIFF
--- a/src/screens/map/MapScreen.tsx
+++ b/src/screens/map/MapScreen.tsx
@@ -10,17 +10,19 @@ import {
 import { useSelector, useDispatch } from 'react-redux';
 import { RootState } from '@/store';
 import { LocationService } from '@/services/LocationService';
-import { setCurrentLocation, setNearbyEcoLocations } from '@/store/slices/locationSlice';
+import { TileService } from '@/services/TileService';
+import { setCurrentLocation, setNearbyEcoLocations, setCurrentTile } from '@/store/slices/locationSlice';
 import { EcoLocation, EcoLocationType, GreenPlanTarget } from '@/types';
 
 export function MapScreen() {
   const dispatch = useDispatch();
-  const { currentLocation, nearbyEcoLocations } = useSelector(
+  const { currentLocation, nearbyEcoLocations, currentTile } = useSelector(
     (state: RootState) => state.location
   );
   const [selectedLocation, setSelectedLocation] = useState<EcoLocation | null>(null);
-  
+
   const locationService = new LocationService();
+  const tileService = new TileService();
 
   useEffect(() => {
     loadCurrentLocation();
@@ -36,6 +38,8 @@ export function MapScreen() {
     try {
       const location = await locationService.getCurrentLocation();
       dispatch(setCurrentLocation(location));
+      const tile = tileService.getTileFromLocation(location);
+      dispatch(setCurrentTile(tile));
     } catch (error) {
       console.error('Error getting location:', error);
       Alert.alert('Error', 'Failed to get current location');
@@ -156,7 +160,12 @@ export function MapScreen() {
         <Text style={styles.subtitle}>
           Find nearby sustainable locations
         </Text>
-        
+        {currentTile && (
+          <Text style={styles.tileInfo}>
+            Tile: {currentTile.zoom}/{currentTile.x}/{currentTile.y}
+          </Text>
+        )}
+
         {currentLocation && (
           <TouchableOpacity
             style={styles.refreshButton}
@@ -251,6 +260,11 @@ const styles = StyleSheet.create({
     fontSize: 16,
     color: '#A8D5BA',
     marginBottom: 16,
+  },
+  tileInfo: {
+    fontSize: 12,
+    color: '#A8D5BA',
+    marginBottom: 8,
   },
   refreshButton: {
     backgroundColor: '#2D5A27',

--- a/src/services/TileService.ts
+++ b/src/services/TileService.ts
@@ -1,0 +1,40 @@
+import { Location, MapTile } from '@/types';
+
+/**
+ * Utility service for working with slippy map tiles.
+ * This mimics the grid based world navigation used in games like Pokémon GO.
+ */
+export class TileService {
+  private readonly defaultZoom = 15;
+
+  /**
+   * Convert a geographic location to a map tile coordinate.
+   * @param location Geographic coordinates.
+   * @param zoom Zoom level for the tile grid.
+   */
+  getTileFromLocation(location: Location, zoom: number = this.defaultZoom): MapTile {
+    const latRad = location.latitude * Math.PI / 180;
+    const n = 2 ** zoom;
+    const x = Math.floor((location.longitude + 180) / 360 * n);
+    const y = Math.floor((1 - Math.log(Math.tan(latRad) + 1 / Math.cos(latRad)) / Math.PI) / 2 * n);
+    return { x, y, zoom };
+  }
+
+  /**
+   * Get surrounding tiles around a location within a given range.
+   * @param location Center location.
+   * @param range Number of tiles around the center tile to include.
+   * @param zoom Zoom level.
+   */
+  getSurroundingTiles(location: Location, range: number = 1, zoom: number = this.defaultZoom): MapTile[] {
+    const center = this.getTileFromLocation(location, zoom);
+    const tiles: MapTile[] = [];
+    for (let dx = -range; dx <= range; dx++) {
+      for (let dy = -range; dy <= range; dy++) {
+        tiles.push({ x: center.x + dx, y: center.y + dy, zoom });
+      }
+    }
+    return tiles;
+  }
+}
+

--- a/src/store/slices/locationSlice.ts
+++ b/src/store/slices/locationSlice.ts
@@ -1,5 +1,5 @@
 import { createSlice, PayloadAction } from '@reduxjs/toolkit';
-import { Location, EcoLocation } from '@/types';
+import { Location, EcoLocation, MapTile } from '@/types';
 
 interface LocationState {
   currentLocation: Location | null;
@@ -8,6 +8,7 @@ interface LocationState {
   isLoading: boolean;
   error: string | null;
   permissionGranted: boolean;
+  currentTile: MapTile | null;
 }
 
 const initialState: LocationState = {
@@ -17,6 +18,7 @@ const initialState: LocationState = {
   isLoading: false,
   error: null,
   permissionGranted: false,
+  currentTile: null,
 };
 
 export const locationSlice = createSlice({
@@ -43,14 +45,18 @@ export const locationSlice = createSlice({
     setError: (state, action: PayloadAction<string>) => {
       state.error = action.payload;
     },
+    setCurrentTile: (state, action: PayloadAction<MapTile>) => {
+      state.currentTile = action.payload;
+    },
   },
 });
 
-export const { 
-  setCurrentLocation, 
-  setNearbyEcoLocations, 
+export const {
+  setCurrentLocation,
+  setNearbyEcoLocations,
   addVisitedLocation,
   setPermissionGranted,
   setLoading,
-  setError 
+  setError,
+  setCurrentTile,
 } = locationSlice.actions;

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -12,6 +12,12 @@ export interface Coordinates {
   lng: number;
 }
 
+export interface MapTile {
+  x: number;
+  y: number;
+  zoom: number;
+}
+
 export enum CreatureType {
   GREENIE = 'greenie',
   SPARKIE = 'sparkie',


### PR DESCRIPTION
## Summary
- track player position via map tiles similar to Pokémon GO
- expose TileService to derive current and surrounding tiles
- surface current tile information on map screen

## Testing
- `npm test` *(fails: jest: not found)*
- `npm install` *(fails: ERESOLVE unable to resolve dependency tree)*
- `npm install --legacy-peer-deps` *(fails: 403 Forbidden)*

